### PR TITLE
Add customizable overlap plots to sample notebook

### DIFF
--- a/Sample Notebooks/BAR_Estimator_Basic_w_Overlap.ipynb
+++ b/Sample Notebooks/BAR_Estimator_Basic_w_Overlap.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "708b4d0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import safep\n",
+    "import alchemlyb\n",
+    "from glob import glob\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import os\n",
+    "from alchemlyb.parsing import namd\n",
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "from alchemlyb.estimators import BAR\n",
+    "import warnings\n",
+    "warnings.simplefilter(action='ignore', category=FutureWarning)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9d06104",
+   "metadata": {},
+   "source": [
+    "# User parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e67078a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path='.'\n",
+    "filename='*.fepout'\n",
+    "\n",
+    "temperature = 303.15\n",
+    "RT = 0.00198720650096 * temperature\n",
+    "decorrelate = True #Flag for decorrelation of samples\n",
+    "detectEQ = True #Flag for automated equilibrium detection\n",
+    "\n",
+    "fepoutFiles = glob(path + '/' + filename)\n",
+    "totalSize = 0\n",
+    "for file in fepoutFiles:\n",
+    "    totalSize += os.path.getsize(file)\n",
+    "print(f\"Will process {len(fepoutFiles)} fepout files.\\nTotal size:{np.round(totalSize/10**9, 2)}GB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30721156",
+   "metadata": {},
+   "source": [
+    "# Extract key features from the MBAR fitting and get ΔG\n",
+    "Note: alchemlyb operates in units of kT by default. We multiply by RT to convert to units of kcal/mol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c747b75-8fa3-48f9-9ab3-ac4a12982c01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "u_nk = namd.extract_u_nk(fepoutFiles, temperature)\n",
+    "safep.plot_samples(ax, u_nk, color='blue', label='Raw Data')\n",
+    "\n",
+    "if detectEQ:\n",
+    "    print(\"Detecting equilibrium\")\n",
+    "    u_nk = safep.detect_equilibrium_u_nk(u_nk)\n",
+    "    safep.plot_samples(ax, u_nk, color='orange', label='Equilibrium-Detected')\n",
+    "if decorrelate:\n",
+    "    print(\"Decorrelating\")\n",
+    "    u_nk = safep.decorrelate_u_nk(u_nk)\n",
+    "    safep.plot_samples(ax, u_nk, color='green', label='Decorrelated')\n",
+    "    \n",
+    "plt.savefig(f\"{path}FEP_number_of_samples.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e81f216",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "perWindow, cumulative = safep.do_estimation(u_nk) #Run the BAR estimator on the fep data\n",
+    "forward, forward_error, backward, backward_error = safep.do_convergence(u_nk) #Used later in the convergence plot'\n",
+    "per_lambda_convergence = safep.do_per_lambda_convergence(u_nk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd69e9c8-94d8-4a2a-9ec8-a24f78059431",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dG = np.round(cumulative.BAR.f.iloc[-1]*RT, 1)\n",
+    "error = np.round(cumulative.BAR.errors.iloc[-1]*RT, 1)\n",
+    "\n",
+    "changeAndError = f'\\u0394G = {dG}\\u00B1{error} kcal/mol'\n",
+    "Markdown('<font size=5>{}</font><br/>'.format(changeAndError))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "282938bb-988e-4e00-a2e6-ab018722569e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = safep.plot_general(cumulative, None, perWindow, None, RT)\n",
+    "fig.suptitle(changeAndError)\n",
+    "plt.savefig(f'{path}FEP_general_figures.pdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7f90d8c",
+   "metadata": {},
+   "source": [
+    "# Plot the estimated total change in free energy as a function of simulation time; contiguous subsets starting at t=0 (\"Forward\") and t=end (\"Reverse\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70523392-e935-4ff4-b6e9-cf679c787bcc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, convAx = plt.subplots(1,1)\n",
+    "convAx = safep.convergence_plot(convAx, forward*RT, forward_error*RT, backward*RT, backward_error*RT)\n",
+    "plt.savefig(f'{path}FEP_convergence.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bf6ac36-f102-4da3-82d2-36a7741584e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.errorbar(per_lambda_convergence.index, per_lambda_convergence.BAR.df*RT)\n",
+    "ax.set_xlabel(r\"$\\lambda$\")\n",
+    "ax.set_ylabel(r\"$D_{last-first}$ (kcal/mol)\")\n",
+    "plt.savefig(f\"{path}FEP_perLambda_convergence.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c978455c-2e63-453d-8631-473ac1b27ab6",
+   "metadata": {},
+   "source": [
+    "# Comparison energy distribution plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b237a8ee-f33e-4c05-b4ed-856bb4f34ca2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "\n",
+    "def plot(ax, fwd, bwd, bar, vlines=True):\n",
+    "    sns.kdeplot(fwd,ax=ax)\n",
+    "    sns.kdeplot(-1 * bwd,ax=ax)\n",
+    "    f = EXP(fwd)\n",
+    "    b = -EXP(bwd)\n",
+    "    if vlines:\n",
+    "        ax.axvline(f,linestyle='-',color=colors[0])\n",
+    "        ax.axvline(b,linestyle='-',color=colors[1])\n",
+    "        ax.axvline(bar,linestyle='-',color=colors[2])\n",
+    "\n",
+    "def EXP(data):\n",
+    "    return - RT * np.log(np.mean(np.exp(- data / RT)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "861db0ca-6baa-4688-a448-ed54ccac2659",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reformat dataframe to access dE series\n",
+    "\n",
+    "states = u_nk.columns.values.tolist()\n",
+    "groups = u_nk.groupby(level=u_nk.index.names[1:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0e0f091-594c-4cbd-a7b9-211e7e915ffd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose windows for which to plot overlap\n",
+    "\n",
+    "overlap_plots = [0, len(states)-2]     # First and last windows\n",
+    "# overlap_plots = range(len(states)-1)   # All windows\n",
+    "# overlap_plots = [3,12]                 #Custom set of windows\n",
+    "\n",
+    "# Number of columns of gaph array\n",
+    "cols = 2\n",
+    "figsize = (16,7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd49510c-c0a2-44f9-bbcb-71aec88b40b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib.lines import Line2D\n",
+    "from math import ceil\n",
+    "\n",
+    "for k in overlap_plots:\n",
+    "    assert k <= len(states) - 1, ('Invalid window number: ' + str(k) +\n",
+    "                                  ' - valid numbers are 0 to ' + str(len(states) - 1))\n",
+    "\n",
+    "nplots = len(overlap_plots)\n",
+    "rows = ceil(nplots / cols)\n",
+    "# Pad the end of the rectangular layout with blank spaces\n",
+    "layout_items = [str(i) for i in overlap_plots] + ['.'] * (rows * cols - nplots)\n",
+    "layout=[[layout_items[r * cols + c] for c in range(cols)] for r in range(rows)]\n",
+    "\n",
+    "fig=plt.figure(figsize=figsize)\n",
+    "gs=fig.subplot_mosaic(layout, gridspec_kw={'hspace' : 0.25})\n",
+    "\n",
+    "prop_cycle=plt.rcParams['axes.prop_cycle']\n",
+    "colors=prop_cycle.by_key()['color']\n",
+    "\n",
+    "fig.legend([Line2D([0],[0],color='tab:blue'),Line2D([0],[0],color='tab:orange'),Line2D([0],[0],color='tab:green')],\n",
+    "           ['forward EXP','backward EXP', 'BAR'])\n",
+    "\n",
+    "for k in overlap_plots:\n",
+    "    uk = groups.get_group(states[k])\n",
+    "    w_f = uk.iloc[:, k+1] - uk.iloc[:, k]\n",
+    "    uk1 = groups.get_group(states[k+1])\n",
+    "    w_r = uk1.iloc[:, k] - uk1.iloc[:, k+1]\n",
+    "    \n",
+    "    plot(gs[str(k)], w_f, w_r, perWindow['BAR']['df'].iloc[k])\n",
+    "    gs[str(k)].set(ylabel=None)\n",
+    "    gs[str(k)].set_title(str(states[k])+' ↔ '+str(states[k+1]))\n",
+    "    # gs[str(k)].set_title(str(states[k])+' ↔ '+str(states[k+1]), x=0.25, y=0.8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "021b89d7-fe78-474d-ba9f-26a0533de10e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
For now I've added them to a new variant of the Basic notebook.

TODO:
- [ ] Decide whether they could either go into the standard Basic notebook, or into the Extended one
- [ ] Some of the helper functions should probably be hidden away in the safep module
- [ ] The seaborn KDE plots could be replaced by what's used elsewhere in safep for consistency