### PR TITLE
Now compatible with Matplotlib 3.8.2

### DIFF
--- a/safep/AFEP_parse.py
+++ b/safep/AFEP_parse.py
@@ -1,10 +1,5 @@
 #Large datasets can be difficult to parse on a workstation due to inefficiencies in the way data is represented for pymbar. When possible, reduce the size of your dataset.
 import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-
-from numpy.lib.stride_tricks import sliding_window_view
-from scipy.stats import linregress as lr
-from scipy.stats import norm
 
 from glob import glob #file regexes
 import pandas as pd

--- a/safep/estimators.py
+++ b/safep/estimators.py
@@ -1,6 +1,5 @@
 # Import block
 import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 import numpy as np
 from numpy.lib.stride_tricks import sliding_window_view

--- a/safep/fileIO.py
+++ b/safep/fileIO.py
@@ -1,28 +1,8 @@
 # Import block
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-
 import numpy as np
-from numpy.lib.stride_tricks import sliding_window_view
-
-from scipy.stats import linregress as lr
-from scipy.stats import norm
-from scipy.special import erfc
-from scipy.optimize import curve_fit as scipyFit
-from scipy.stats import skew
-
 import pandas as pd
 
-from alchemlyb.visualisation.dF_state import plot_dF_state
-from alchemlyb.parsing import namd
-from alchemlyb.estimators import BAR
-from alchemlyb.visualisation.dF_state import plot_dF_state
-from alchemlyb.visualisation import plot_convergence
-
 import re
-from tqdm import tqdm #for progress bars
-from natsort import natsorted #for sorting "naturally" instead of alphabetically
-from glob import glob #file regexes
 
 from .helpers import *
 

--- a/safep/helpers.py
+++ b/safep/helpers.py
@@ -1,28 +1,7 @@
 # Import block
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-
 import numpy as np
-from numpy.lib.stride_tricks import sliding_window_view
 
-from scipy.stats import linregress as lr
 from scipy.stats import norm
-from scipy.special import erfc
-from scipy.optimize import curve_fit as scipyFit
-from scipy.stats import skew
-
-import pandas as pd
-
-from alchemlyb.visualisation.dF_state import plot_dF_state
-from alchemlyb.parsing import namd
-from alchemlyb.estimators import BAR
-from alchemlyb.visualisation.dF_state import plot_dF_state
-from alchemlyb.visualisation import plot_convergence
-
-import re
-from tqdm import tqdm #for progress bars
-from natsort import natsorted #for sorting "naturally" instead of alphabetically
-from glob import glob #file regexes
 
 # Calculate the coefficient of determination:
 def get_Rsq(X, Y, Yexpected):

--- a/safep/plotting.py
+++ b/safep/plotting.py
@@ -1,29 +1,8 @@
 # Import block
 import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-
 import numpy as np
-from numpy.lib.stride_tricks import sliding_window_view
-
-from scipy.stats import linregress as lr
-from scipy.stats import norm
-from scipy.special import erfc
-from scipy.optimize import curve_fit as scipyFit
-from scipy.stats import skew
 import scipy as sp
-
 import pandas as pd
-
-from alchemlyb.visualisation.dF_state import plot_dF_state
-from alchemlyb.parsing import namd
-from alchemlyb.estimators import BAR
-from alchemlyb.visualisation.dF_state import plot_dF_state
-from alchemlyb.visualisation import plot_convergence
-
-import re
-from tqdm import tqdm #for progress bars
-from natsort import natsorted #for sorting "naturally" instead of alphabetically
-from glob import glob #file regexes
 
 from .helpers import *
 from .processing import get_n_samples

--- a/safep/processing.py
+++ b/safep/processing.py
@@ -1,30 +1,19 @@
 # Import block
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 import numpy as np
 from numpy.lib.stride_tricks import sliding_window_view
 
 from scipy.stats import linregress as lr
 from scipy.stats import norm
-from scipy.special import erfc
 from scipy.optimize import curve_fit as scipyFit
-from scipy.stats import skew
 
 import pandas as pd
 
-from alchemlyb.visualisation.dF_state import plot_dF_state
 from alchemlyb.parsing import namd
 from alchemlyb.estimators import BAR
-from alchemlyb.visualisation.dF_state import plot_dF_state
-from alchemlyb.visualisation import plot_convergence
 from alchemlyb.preprocessing import subsampling
 
-import re
-from tqdm import tqdm  # for progress bars
-from natsort import (
-    natsorted,
-)  # for sorting "naturally" instead of alphabetically
+from natsort import natsorted
 from glob import glob  # file regexes
 
 from .helpers import *

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='safep',
-    version='0.1.2.3',    
+    version='0.1.3',
     description='Tools for Analyzing and Debugging (SA)FEP calculations',
     url='https://github.com/BranniganLab/safep',
     author='Brannigan Lab',


### PR DESCRIPTION
Old, unused imports were causing errors because they were importing deprecated modules from Matplotlib.
Those unused imports have been removed.