### PR TITLE
73 sterr should be standard error when possible

### DIFF
--- a/safep/AFEP_parse.py
+++ b/safep/AFEP_parse.py
@@ -432,13 +432,14 @@ def get_summary_statistics(args, fepruns):
 
     # If there are only a few replicas,
     # the MBAR estimated error will be more reliable, albeit underestimated
-    sterr, toprint = get_sterr(dGs, errors, mean, toprint)
+    sterr = np.round(get_sterr(dGs, errors), 1)
+    toprint += f"mean: {mean} kcal/mol\n" + f"sterr: {sterr} kcal/mol"
     if np.isnan(mean):
         raise RuntimeError("Free energy average is NaN")
     return toprint, dGs, mean, sterr
 
 
-def get_sterr(dGs, errors, mean=None, toprint=""):
+def get_sterr(dGs, errors):
     """Get the standard error of the dGs
 
     args:
@@ -452,13 +453,10 @@ def get_sterr(dGs, errors, mean=None, toprint=""):
     """
     if len(dGs) < 3:
         sterr = np.sqrt(np.sum(np.square(errors)))
-        # Nothing new to print
+        print("Warning: Not enough replicas for a standard error. Propagating BAR errors.")
     else:
-        sterr = np.round(np.std(dGs), 1)
-        if mean is None:
-            mean = np.mean(dGs)
-        toprint += f"mean: {mean} kcal/mol\n" + f"sterr: {sterr} kcal/mol"
-    return sterr, toprint
+        sterr = np.std(dGs)
+    return sterr
 
 
 def main():

--- a/safep/AFEP_parse.py
+++ b/safep/AFEP_parse.py
@@ -432,15 +432,33 @@ def get_summary_statistics(args, fepruns):
 
     # If there are only a few replicas,
     # the MBAR estimated error will be more reliable, albeit underestimated
+    sterr, toprint = get_sterr(dGs, errors, mean, toprint)
+    if np.isnan(mean):
+        raise RuntimeError("Free energy average is NaN")
+    return toprint, dGs, mean, sterr
+
+
+def get_sterr(dGs, errors, mean=None, toprint=""):
+    """Get the standard error of the dGs
+
+    args:
+        dGs (list): list of free energies
+        errors (list): list of errors corresponding to dGs
+        mean (float): mean free energy across replicas. Default None.
+        toprint (str): log string. Default empty.
+
+    returns:
+        float, str: the standard error of the dGs and an updated print string
+    """
     if len(dGs) < 3:
         sterr = np.sqrt(np.sum(np.square(errors)))
         # Nothing new to print
     else:
         sterr = np.round(np.std(dGs), 1)
+        if mean is None:
+            mean = np.mean(dGs)
         toprint += f"mean: {mean} kcal/mol\n" + f"sterr: {sterr} kcal/mol"
-    if np.isnan(mean):
-        raise RuntimeError("Free energy average is NaN")
-    return toprint, dGs, mean, sterr
+    return sterr, toprint
 
 
 def main():

--- a/safep/AFEP_parse.py
+++ b/safep/AFEP_parse.py
@@ -455,7 +455,7 @@ def get_sterr(dGs, errors):
         sterr = np.sqrt(np.sum(np.square(errors)))
         print("Warning: Not enough replicas for a standard error. Propagating BAR errors.")
     else:
-        sterr = np.std(dGs)
+        sterr = np.std(dGs, ddof=1)/np.sqrt(len(dGs))
     return sterr
 
 

--- a/safep/tests/test_afep_parse.py
+++ b/safep/tests/test_afep_parse.py
@@ -37,7 +37,7 @@ def test_sterr_of_five_numbers_is_correct():
     errors = [1,1,1,1,1]
     sterr = get_sterr(dGs, errors)
     assert not np.isclose(sterr, 1.58113883), "Got standard deviation, not standard error"
-    assert np.isclose(sterr, 0.7071067812), "Wrong standard error"
+    assert np.isclose(sterr, 0.7071067812), f"Got: {sterr}. Expected: 0.7071067812"
 
 def test_sterr_of_two_numbers_propagates_error():
     dGs = [3,4]

--- a/safep/tests/test_afep_parse.py
+++ b/safep/tests/test_afep_parse.py
@@ -1,5 +1,6 @@
+import numpy as np
 from approvaltests import verify
-from safep.AFEP_parse import  COLORS, get_summary_statistics, AFEPArguments
+from safep.AFEP_parse import  COLORS, get_summary_statistics, AFEPArguments, get_sterr
 from safep.fepruns import process_replicas
 import pytest
 from pathlib import Path
@@ -30,3 +31,18 @@ def test_u_nk(fepruns):
     u_nk = fepruns["Replica1"].u_nk
     string = u_nk.to_csv(index=False)
     verify(string)
+
+def test_sterr_of_five_numbers_is_correct():
+    dGs = [1,2,3,4,5]
+    errors = [1,1,1,1,1]
+    sterr = get_sterr(dGs, errors)
+    assert not np.isclose(sterr, 1.58113883), "Got standard deviation, not standard error"
+    assert np.isclose(sterr, 0.7071067812), "Wrong standard error"
+
+def test_sterr_of_two_numbers_propagates_error():
+    dGs = [3,4]
+    errors = [1,2]
+    sterr = get_sterr(dGs, errors)
+    assert not np.isclose(sterr, 0.7071067812), "Got standard deviation, not propagated error"
+    assert not np.isclose(sterr, 0.5), "Got standard error. Standard error of two numbers is a math crime. The authorities have been informed."
+    assert np.isclose(sterr, 2.236067977), "Error not propagated correctly."


### PR DESCRIPTION
## To do:
- [x] Add pytests for standard error calculation
- [x] Extract standard error calculation to a stand-alone function
- [x] Calculate the _sample_ standard error when there are at least 3 replicas
- [x] Propagate BAR errors when there are fewer than three replicas
- [x] Documentation

## Pre-Review checklist (PR maker)
- [x] Pytests pass ( `pytest safep/tests` passes all 11 tests)
- [x] New functions are documented
- [x] Code is readable

## Review checklist (Reviewer)
- [x] Pytests pass: `pytest safep/tests` passes all 11 tests
- [x] New functions are documented 
- [x] New functions/variables are named appropriately
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] I understand what the changes are doing and how