### PR TITLE
HOTFIX minor version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     ]
 
 name = 'safep'
-version = "0.1.4"
+version = "0.1.5"
 
 authors = [{name='Brannigan Lab', email='grace.brannigan@rutgers.edu'}]
 


### PR DESCRIPTION
The current version number wasn't updated in recent PRs. Incrementing to 0.1.5 so that the pypi package can be updated.