### PR TITLE
Add legend to per-window change plot in plot_general

### DIFF
--- a/safep/plotting.py
+++ b/safep/plotting.py
@@ -193,7 +193,7 @@ def plot_general(cumulative,
 
     each_ax.plot(per_window.index, per_window.EXP.dG_f*RT, marker=None, linewidth=1, alpha=0.5, color=color, label="forward EXP")
     each_ax.plot(per_window.index, -per_window.EXP.dG_b*RT, marker=None, linewidth=1, alpha=0.5, linestyle='--', color=color, label="backward EXP")
-
+    each_ax.legend()
     each_ax.set(ylabel=r'$\mathrm{\Delta} G_\lambda$'+'\n'+r'$\left(\mathrm{kcal}/\mathrm{mol}\right)$', ylim=per_window_ylim)
 
     #Hysteresis Plots


### PR DESCRIPTION
I noticed the plot showing the per window change in delta G is missing a legend when using the SAFEP tutorial notebook

## To do:
- [ ] Aims of the PR

## Acceptance Tests:
Describe any manual tests that the reviewer should run including explicit commands and expected outputs

## Pre-Review checklist (PR maker)
- [ ] Acceptance tests pass
- [ ] Pytests pass ( `pytest safep/tests` passes all N tests)
- [ ] New functions are documented
- [ ] Code is readable

## Review checklist (Reviewer)
- [ ] Acceptance tests pass
- [ ] Pytests pass: `pytest safep/tests` passes all N tests
- [ ] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] I understand what the changes are doing and how
