### PR TITLE
HOTFIX: preserve backward compatibility with python 3.11

### DIFF
--- a/safep/RFEP_analysis.py
+++ b/safep/RFEP_analysis.py
@@ -37,7 +37,7 @@ def main(logfile: str | Path) -> None:
     if restraint is None:
         raise ValueError("No changing bias found in the provided logfile.")
     print(
-        f"Processing TI data for restraint {restraint["name"]} on CVs {restraint["colvar"]}"
+        f"Processing TI data for restraint {restraint['name']} on CVs {restraint['colvar']}"
     )
 
     # We assume the colvars traj and log are in the same directory


### PR DESCRIPTION
fix #91 
## To do:
- [x] Fix backward compatibility (nested double quotes are introduced in python 3.12 https://peps.python.org/pep-0701/

## Acceptance Tests:
Pytests should be sufficient

## Pre-Review checklist (PR maker)
- [x] Acceptance tests pass
- [x] Pytests pass ( `pytest safep/tests` passes all 14 tests)
- [x] New functions are documented
- [x] Code is readable

## Review checklist (Reviewer)
- [x] Acceptance tests pass
- [x] Pytests pass: `pytest safep/tests` passes all N tests
- [x] New functions are documented 
- [x] New functions/variables are named appropriately
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] I understand what the changes are doing and how
