### PR TITLE
94 general plot center panel lacks legend

### DIFF
--- a/safep/AFEP_parse.py
+++ b/safep/AFEP_parse.py
@@ -165,7 +165,6 @@ def initialize_general_figure(RT_kcal_per_mol, key, feprun):
         label=key,
         color=feprun.color,
     )
-    axes[1].legend()
 
     return fig, axes
 

--- a/safep/plotting.py
+++ b/safep/plotting.py
@@ -193,7 +193,13 @@ def plot_general(cumulative,
 
     each_ax.plot(per_window.index, per_window.EXP.dG_f*RT, marker=None, linewidth=1, alpha=0.5, color=color, label="forward EXP")
     each_ax.plot(per_window.index, -per_window.EXP.dG_b*RT, marker=None, linewidth=1, alpha=0.5, linestyle='--', color=color, label="backward EXP")
-    each_ax.legend()
+
+    if each_ax.get_legend() is None:
+        line_bar, = each_ax.plot([],[], marker=None, linewidth=1, color="k", label="BAR")
+        line_fwd, = each_ax.plot([],[], marker=None, linewidth=1, alpha=0.5, color="k",label="forward EXP")
+        line_bwd, = each_ax.plot([],[], marker=None, linewidth=1, alpha=0.5, linestyle='--',color="k", label="backward EXP")
+        each_ax.legend(handles=[line_bar, line_fwd, line_bwd])
+
     each_ax.set(ylabel=r'$\mathrm{\Delta} G_\lambda$'+'\n'+r'$\left(\mathrm{kcal}/\mathrm{mol}\right)$', ylim=per_window_ylim)
 
     #Hysteresis Plots

--- a/safep/plotting.py
+++ b/safep/plotting.py
@@ -193,7 +193,7 @@ def plot_general(cumulative,
 
     each_ax.plot(per_window.index, per_window.EXP.dG_f*RT, marker=None, linewidth=1, alpha=0.5, color=color, label="forward EXP")
     each_ax.plot(per_window.index, -per_window.EXP.dG_b*RT, marker=None, linewidth=1, alpha=0.5, linestyle='--', color=color, label="backward EXP")
-
+    each_ax.legend()
     each_ax.set(ylabel=r'$\mathrm{\Delta} G_\lambda$'+'\n'+r'$\left(\mathrm{kcal}/\mathrm{mol}\right)$', ylim=per_window_ylim)
 
     #Hysteresis Plots


### PR DESCRIPTION
## To do:
- [x] Add a generic legend to the center panel of the general plots

## Acceptance Tests:
When the BAR_Estimator_Basic.ipynb notebook is run (in the Sample_Notebooks directory), the general plot will have a legend in it with exactly one of each: forward, backward, BAR.
<img width="398" height="267" alt="image" src="https://github.com/user-attachments/assets/50feea25-5f95-45bd-b4d1-48be523f308e" />

## Pre-Review checklist (PR maker)
- [x] Acceptance tests pass
- [x] Pytests pass ( `pytest safep/tests` passes all N tests)
- [x] New functions are documented
- [x] Code is readable

## Review checklist (Reviewer)
- [x] Acceptance tests pass
- [x] Pytests pass: `pytest safep/tests` passes all N tests
- [x] New functions are documented 
- [x] New functions/variables are named appropriately
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] I understand what the changes are doing and how


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plot legends by adding them directly to individual windows when missing.
  * Legends now include representative entries for bar, forward exponential, and backward exponential series.
  * Removed redundant legend creation during general figure setup to keep chart presentation consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->